### PR TITLE
Update tab structure and adjust tab count for standards section

### DIFF
--- a/src/pages/en/our-standard.astro
+++ b/src/pages/en/our-standard.astro
@@ -228,6 +228,14 @@ const pdpa = [
         </style>
       </div>
     </div>
+
+    <!-- PDPA DPO Tab Content -->
+    <div id="PDPADPO" class="tab-content">
+      <div class="pt-4 flex justify-center flex-col items-center gap-0">
+        <Headline title="PDPA DPO" classes={{ container: 'mt-2 md:pt-4 lg:pt-6 lg:mb-8' }} />
+        
+      </div>
+    </div>
   </WidgetWrapper>
 </Layout>
 
@@ -345,11 +353,16 @@ header .slider {
   document.addEventListener('astro:page-load', () => {
     const inputs = document.querySelectorAll('input[name="slider"]');
     const contents = document.querySelectorAll('.tab-content');
+    contents.forEach((content) => content.classList.remove('active'));
+    
+    contents[0].classList.add('active'); // Activate the first tab by default
+    console.log(`Content:`, contents);
 
     inputs.forEach((input, index) => {
       input.addEventListener('change', () => {
         contents.forEach((content) => content.classList.remove('active'));
         contents[index].classList.add('active');
+        
       });
     });
   });

--- a/src/pages/en/our-standard.astro
+++ b/src/pages/en/our-standard.astro
@@ -119,7 +119,7 @@ const pdpa = [
 <Layout metadata={metadata}>
   <WidgetWrapper containerClass="max-w-7xl mx-auto">
     <!-- Tabs -->
-    <!-- <div class="wrapper mt-12 xl:mt-0 mb-[-40px] xl:mb-[-0px]">
+    <div class="wrapper mt-12 xl:mt-0 mb-[-40px] xl:mb-[-0px]">
       <input type="radio" name="slider" id="tab-1" checked />
       <input type="radio" name="slider" id="tab-2" />
       <input type="radio" name="slider" id="tab-3" />
@@ -131,7 +131,7 @@ const pdpa = [
         <label for="tab-4" class="tab-4">PDPA DPO</label>
         <div class="slider"></div>
       </header>
-    </div> -->
+    </div>
 
     <!-- Standards Tab Content -->
     <div id="standards" class="tab-content ">
@@ -260,7 +260,7 @@ const pdpa = [
 
   /*---------- slider tab selector -----------*/
   :root {
-  --tab-count: 1; /* Change this to match the number of tabs */
+  --tab-count: 4; /* Change this to match the number of tabs */
 }
 
 .wrapper {

--- a/src/pages/en/our-standard.astro
+++ b/src/pages/en/our-standard.astro
@@ -119,7 +119,7 @@ const pdpa = [
 <Layout metadata={metadata}>
   <WidgetWrapper containerClass="max-w-7xl mx-auto">
     <!-- Tabs -->
-    <div class="wrapper mt-12 xl:mt-0 mb-[-40px] xl:mb-[-0px]">
+    <div class="wrapper mt-12 xl:mt-0">
       <input type="radio" name="slider" id="tab-1" checked />
       <input type="radio" name="slider" id="tab-2" />
       <input type="radio" name="slider" id="tab-3" />
@@ -134,14 +134,14 @@ const pdpa = [
     </div>
 
     <!-- Standards Tab Content -->
-    <div id="standards" class="tab-content ">
+    <div id="standards" class="tab-content active">
       <div class="block-effect" style="--td: 1s">
         <div class="block-reveal pt-4" style="--bc: var(--aw-color-primary); --d: .1ms">
-          <Headline title="มาตรฐานของเรา" classes={{ container: 'pt-14 lg:pt-0 lg:mb-8' }} />
+          <Headline title="Our Standard" classes={{ container: 'mt-2 md:pt-4 lg:pt-6 lg:mb-8' }} />
         </div>
       </div>
       <div class="flex flex-col items-center gap-8 p-4 lg:p-0">
-        <div class="lg:w-1/2">
+        <div class="lg:w-3/4">
           <p class="md:text-md">
             Our company has been assessed and certified for 
             <span class="text-primary">ISO 29110</span> standards in 
@@ -169,9 +169,9 @@ const pdpa = [
     </div>
 
     <!-- Certificates Tab Content -->
-    <div id="certificates" class="tab-content flex justify-center active">
+    <div id="certificates" class="tab-content flex justify-center">
       <div class="pt-4">
-        <Headline title="ใบรับรองของเรา" classes={{ container: 'pt-12 lg:pt-0 lg:mb-8' }} />
+        <Headline title="Our Certificates" classes={{ container: 'mt-2 md:pt-4 lg:pt-6 lg:mb-8' }} />
       </div>
       <div class="flex justify-center md:items-center xl:items-start">
         <p class="text-md">
@@ -198,7 +198,7 @@ const pdpa = [
     <!-- PDPA Tab Content -->
     <div id="PDPA" class="tab-content">
       <div class="pt-4 flex justify-center flex-col items-center gap-0">
-        <Headline title="PDPA" classes={{ container: 'pt-12 lg:pt-0 lg:mb-8' }} />
+        <Headline title="PDPA" classes={{ container: 'mt-2 md:pt-4 lg:pt-6 lg:mb-8' }} />
         <div class="flex justify-center md:items-center xl:items-start">
           <p class="flex justify-center md:text-lg md:flex-row flex-col items-center">
             Our team has been trained in

--- a/src/pages/our-standard.astro
+++ b/src/pages/our-standard.astro
@@ -119,7 +119,7 @@ const pdpa = [
 <Layout metadata={metadata}>
   <WidgetWrapper containerClass="max-w-7xl mx-auto">
     <!-- Tabs -->
-    <div class="wrapper mt-12 xl:mt-0 mb-[-40px] xl:mb-[-0px]">
+    <div class="wrapper mt-12 xl:mt-0">
       <input type="radio" name="slider" id="tab-1" checked />
       <input type="radio" name="slider" id="tab-2" />
       <input type="radio" name="slider" id="tab-3" />
@@ -137,7 +137,7 @@ const pdpa = [
     <div id="standards" class="tab-content ">
       <div class="block-effect" style="--td: 1s">
         <div class="block-reveal pt-4" style="--bc: var(--aw-color-primary); --d: .1ms">
-          <Headline title="มาตรฐานของเรา" classes={{ container: 'pt-14 lg:pt-0 lg:mb-8' }} />
+          <Headline title="มาตรฐานของเรา" classes={{ container: 'mt-2 md:pt-4 lg:pt-6 lg:mb-8' }} />
         </div>
       </div>
       <div class="flex flex-col items-center gap-8 p-4 lg:p-0">
@@ -171,7 +171,7 @@ const pdpa = [
     <!-- Certificates Tab Content -->
     <div id="certificates" class="tab-content flex justify-center active">
       <div class="pt-4">
-        <Headline title="ใบรับรองของเรา" classes={{ container: 'pt-12 lg:pt-0 lg:mb-8' }} />
+        <Headline title="ใบรับรองของเรา" classes={{ container: 'mt-2 md:pt-4 lg:pt-6 lg:mb-8' }} />
       </div>
       <div class="flex justify-center md:items-center xl:items-start">
         <p class="text-md">
@@ -198,7 +198,7 @@ const pdpa = [
     <!-- PDPA Tab Content -->
     <div id="PDPA" class="tab-content">
       <div class="pt-4 flex justify-center flex-col items-center gap-0">
-        <Headline title="PDPA" classes={{ container: 'pt-12 lg:pt-0 lg:mb-8' }} />
+        <Headline title="PDPA" classes={{ container: 'mt-2 md:pt-4 lg:pt-6 lg:mb-8' }} />
         <div class="flex justify-center md:items-center xl:items-start">
           <p class="flex justify-center md:text-lg md:flex-row flex-col items-center">
         ทีมงานของเราได้ผ่านการอบรมเกี่ยวกับ
@@ -226,6 +226,14 @@ const pdpa = [
             transform: scale(1.1);
           }
         </style>
+      </div>
+    </div>
+
+    <!-- PDPA DPO Tab Content -->
+    <div id="PDPADPO" class="tab-content">
+      <div class="pt-4 flex justify-center flex-col items-center gap-0">
+        <Headline title="PDPA DPO" classes={{ container: 'mt-2 md:pt-4 lg:pt-6 lg:mb-8' }} />
+        
       </div>
     </div>
   </WidgetWrapper>

--- a/src/pages/our-standard.astro
+++ b/src/pages/our-standard.astro
@@ -119,7 +119,7 @@ const pdpa = [
 <Layout metadata={metadata}>
   <WidgetWrapper containerClass="max-w-7xl mx-auto">
     <!-- Tabs -->
-    <!-- <div class="wrapper mt-12 xl:mt-0 mb-[-40px] xl:mb-[-0px]">
+    <div class="wrapper mt-12 xl:mt-0 mb-[-40px] xl:mb-[-0px]">
       <input type="radio" name="slider" id="tab-1" checked />
       <input type="radio" name="slider" id="tab-2" />
       <input type="radio" name="slider" id="tab-3" />
@@ -131,7 +131,7 @@ const pdpa = [
         <label for="tab-4" class="tab-4">PDPA DPO</label>
         <div class="slider"></div>
       </header>
-    </div> -->
+    </div>
 
     <!-- Standards Tab Content -->
     <div id="standards" class="tab-content ">
@@ -260,7 +260,7 @@ const pdpa = [
 
   /*---------- slider tab selector -----------*/
   :root {
-  --tab-count: 1; /* Change this to match the number of tabs */
+  --tab-count: 4; /* Change this to match the number of tabs */
 }
 
 .wrapper {


### PR DESCRIPTION
## Description

This pull request updates the tab structure and adjusts the tab count for the standards
section on the "our-standard" pages. The changes involve uncommenting the HTML for the
tabbed interface and updating the corresponding CSS to ensure the four tabs are displayed
correctly.

Related Issues

N/A

Checklist

 - [x] ฉันได้ทดสอบการทำงานแล้ว
 - [x] ฉันได้ลองทบทวนหรืออ่านโค้ดที่ฉันเขียนอย่างถี่ถ้วนแล้ว

Screenshots

![image](https://github.com/user-attachments/assets/2b34e8cd-bee9-471a-8b24-a680a5959df3)
![image](https://github.com/user-attachments/assets/198ee596-54b1-4c85-92ff-c069d2bbb652)
